### PR TITLE
moving testing framework into core utils lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ project/plugins/project/
 
 
 .idea/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,76 @@
 # ingestion-utils
 Common utilities used to implement hyppo integrations.
+
+## Test
+
+### Integration Testing
+Common functionality for integration testing with the Hyppo ingestion platform can be found in the test package
+
+The package contains three core components:
+
+ * Tags
+ * TestConfig
+ * HyppoIntegrationTest
+ 
+#### Tags
+[Tagging](http://www.scalatest.org/user_guide/tagging_your_tests), a feature of ScalaTest, is utilized here to mark tests that require database access or a remote API call. By creating these custom tags and tagging tests one can omit running full integration tests during assembly (something which could take a long time depending on the integration).
+
+To tag a test:
+```scala
+"This test does something" taggedAs Tags.RemoteAPICalls in {
+ ...
+}
+
+"This other test does two things" taggedAs (Tags.RemoteAPICalls, Tags.DatabaseAccess) in {
+ ...
+}
+```
+
+To prevent tagged tests from running in a particular part of the build process, define it in the ```build.sbt```:
+
+```scala
+testOptions in Test += Tests.Argument("-l", "com.harrys.Tags.RemoteAPICalls", "-l", "com.harrys.Tags.DatabaseAccess")
+```
+
+#### TestConfig
+The test config loads values out of the environment and packages them into a representative TypeSafe Config object to be used in testing. To use this object in your tests, you will need to add a ```testing.conf``` file with the desired substitutions to ```test/resources```.
+
+Additionally, there is some required SBT setup. To begin, you'll need to create an integration plugin in your ```project``` directory:
+
+```scala
+import java.util.Properties
+
+import sbt.Keys._
+import sbt._
+import sbt.plugins.JvmPlugin
+
+object MyIntegrationSettingsPlugin extends AutoPlugin {
+  override def requires = JvmPlugin
+
+  override def trigger  = allRequirements
+
+  object autoImport {
+    val environmentFile       = settingKey[File]("The file to load for credentials and properties in the local environment")
+    val environmentProperties = settingKey[Properties]("The values loaded from the environment file")
+  }
+
+  import autoImport._
+
+  override lazy val buildSettings: Seq[Setting[_]] = Seq(
+    environmentFile := baseDirectory.value / "credentials.properties"
+  )
+
+  override lazy val projectSettings: Seq[Def.Setting[_]] = Seq(
+    environmentProperties <<= environmentFile.apply(f => loadEnvironmentFile(f))
+  )
+
+  def loadEnvironmentFile(file: File): Properties = {
+    val props = new Properties()
+    if (!file.isFile){
+      sys.error("Invalid environment file value: " + file.getPath)
+    } else {
+      IO.load(props, file)
+    }
+    props
+  }
+```

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,6 @@ libraryDependencies ++= Seq(
   "org.json4s" %% "json4s-jackson" % "3.2.11",
   "org.json4s" %% "json4s-ext" % "3.2.11",
   "org.postgresql" % "postgresql" % "9.4-1201-jdbc41",
-  "com.harrys.hyppo" % "source-api" % "0.6.0",
+  "com.harrys.hyppo" % "source-api" % "0.6.1",
   "org.scalatest" %% "scalatest"  % "2.2.4"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := """ingestion-util"""
 
 organization := "com.harrys"
 
-version := "0.2.0"
+version := "0.3.0"
 
 scalaVersion := "2.11.7"
 
@@ -17,5 +17,7 @@ libraryDependencies ++= Seq(
   "org.json4s" %% "json4s-core" % "3.2.11",
   "org.json4s" %% "json4s-jackson" % "3.2.11",
   "org.json4s" %% "json4s-ext" % "3.2.11",
-  "org.postgresql" % "postgresql" % "9.4-1201-jdbc41"
+  "org.postgresql" % "postgresql" % "9.4-1201-jdbc41",
+  "com.harrys.hyppo" % "source-api" % "0.6.0",
+  "org.scalatest" %% "scalatest"  % "2.2.4"
 )

--- a/src/main/scala/com/harrys/test/HyppoIntegrationTest.scala
+++ b/src/main/scala/com/harrys/test/HyppoIntegrationTest.scala
@@ -1,0 +1,72 @@
+package com.harrys.test
+
+import java.io.File
+import java.nio.file.Files
+
+import com.harrys.hyppo.source.api.RawDataIntegration
+import com.harrys.hyppo.source.api.data.{AvroRecordAppender, RawDataCollector, AvroRecordType}
+import com.harrys.hyppo.source.api.model.DataIngestionTask
+import com.harrys.hyppo.source.api.task.{PersistProcessedData, ProcessRawData, FetchRawData, CreateIngestionTasks}
+import org.apache.avro.specific.SpecificRecord
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.collection.JavaConversions
+
+/**
+ * Created by chris on 12/26/15.
+ */
+abstract class HyppoIntegrationTest[T <: SpecificRecord] extends WordSpec with Matchers {
+  val integration : RawDataIntegration[T]
+  val avroType : AvroRecordType[T]
+
+  val testJob = TestConfig.createNoParameterJob()
+  val rawData = Files.createTempDirectory("avro").toFile
+
+  var tasks : Seq[DataIngestionTask] = Seq()
+  var rawFiles : Seq[File]           = Seq()
+  var avroFiles : Seq[File]          = Seq()
+
+  def setTasks(tasks: Seq[DataIngestionTask]) : Unit = {
+    this.tasks = tasks.map(t => new DataIngestionTask(testJob, t.getTaskNumber, t.getTaskArguments))
+  }
+
+  def addRawData(file: File): Unit = {
+    rawFiles :+= file
+  }
+
+  def addAvroData(file: File): Unit = {
+    avroFiles :+= file
+  }
+
+  def generateTasksList() : java.util.List[DataIngestionTask] = {
+    val createTasks = new CreateIngestionTasks(testJob)
+    integration.newIngestionTaskCreator().createIngestionTasks(createTasks)
+    val created = createTasks.getTaskBuilder.build()
+    setTasks(JavaConversions.asScalaBuffer(created))
+    created
+  }
+
+  def generateRawDataFetches : Seq[FetchRawData] = {
+    val fetches = tasks.map(t => new FetchRawData(t, new RawDataCollector(rawData)))
+    fetches.foreach { fetch =>
+      integration.newRawDataFetcher().fetchRawData(fetch)
+      addRawData(fetch.getDataFiles.get(0))
+    }
+    fetches
+  }
+
+  def processAndAppendRawData(task: DataIngestionTask, file: File) : AvroRecordAppender[T] = {
+    val outFile = Files.createTempFile("processed", "avro").toFile
+    val appender = avroType.createAvroRecordAppender(outFile)
+    val process = new ProcessRawData[T](task, file, appender)
+    integration.newRawDataProcessor().processRawData(process)
+    appender.close()
+    addAvroData(appender.getOutputFile)
+    appender
+  }
+
+  def persistAvroRecordsToDatabase(task: DataIngestionTask, file: File) : Unit = {
+    val persist = new PersistProcessedData[T](task, avroType, file)
+    integration.newProcessedDataPersister().persistProcessedData(persist)
+  }
+}

--- a/src/main/scala/com/harrys/test/Tags.scala
+++ b/src/main/scala/com/harrys/test/Tags.scala
@@ -1,0 +1,12 @@
+package com.harrys.test
+
+import org.scalatest.Tag
+
+
+/**
+ * Created by chris on 12/26/15.
+ */
+object Tags {
+  val RemoteAPICalls = new Tag("com.harrys.Tags.RemoteAPICalls")
+  val DatabaseAccess = new Tag("com.harrys.Tags.DatabaseAccess")
+}

--- a/src/main/scala/com/harrys/test/TestConfig.scala
+++ b/src/main/scala/com/harrys/test/TestConfig.scala
@@ -31,7 +31,7 @@ object TestConfig {
     val sys   = System.getProperties
     if (sys.containsKey(EnvFileProperty)){
       val env = new File(sys.getProperty(EnvFileProperty))
-      if (!env.isFile){
+      if (!env.exists){
         throw new IllegalArgumentException(s"-Dtest.env-file value of ${ env.getAbsolutePath } is invalid. File does not exist.")
       } else {
         val stream = new FileInputStream(env)

--- a/src/main/scala/com/harrys/test/TestConfig.scala
+++ b/src/main/scala/com/harrys/test/TestConfig.scala
@@ -1,0 +1,47 @@
+package com.harrys.test
+
+import java.io.{FileInputStream, File}
+import java.util.{Date, UUID, Properties}
+import com.typesafe.config.{ConfigFactory, Config}
+import com.harrys.hyppo.source.api.model.{DataIngestionJob, IngestionSource}
+
+/**
+ * Created by chris on 12/26/15.
+ */
+object TestConfig {
+  final val EnvFileProperty = "test.env-file"
+
+  def basicIngestionSource(): IngestionSource = {
+    new IngestionSource("Hyppo Ingestion Test", testConfig())
+  }
+
+  def createNoParameterJob(): DataIngestionJob = {
+    val source = basicIngestionSource()
+    val params = ConfigFactory.empty()
+    new DataIngestionJob(source, UUID.randomUUID(), params, new Date())
+  }
+
+  def testConfig(): Config = {
+    val testProps = ConfigFactory.parseProperties(testProperties())
+    ConfigFactory.parseResources("testing.conf").resolveWith(testProps)
+  }
+
+  def testProperties(): Properties = {
+    val props = new Properties()
+    val sys   = System.getProperties
+    if (sys.containsKey(EnvFileProperty)){
+      val env = new File(sys.getProperty(EnvFileProperty))
+      if (!env.isFile){
+        throw new IllegalArgumentException(s"-Dtest.env-file value of ${ env.getAbsolutePath } is invalid. File does not exist.")
+      } else {
+        val stream = new FileInputStream(env)
+        try {
+          props.load(stream)
+        } finally {
+          stream.close()
+        }
+      }
+    }
+    props
+  }
+}


### PR DESCRIPTION
- Created common integration testing package under com.harrys.test
- Tags: Common tags to be used to prevent testing from running during assembly
- TestConfig: Object that generates a test config from the environment properties
- HyppoIntegrationTest: Abstract class for testing integrations. Contains a couple overrides and the wiring for integration tests so that the tests themselves can simply focus on checking the expected conditions.

For example implementation check out my StripeCharge integration test: https://github.com/harrystech/hyppo-stripe-integration/blob/master/src/test/scala/com/harrys/stripe/integrations/charge/StripeChargeIntegrationTest.scala

This was my first pass on this and would love some feedback. What I have works with the Stripe Charges and I believe should work with all of our other integrations.
